### PR TITLE
Add config to keep UI open after command is executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Default config file: `$XDG_CONFIG_HOME/wlr-which-key/config.yaml` or `~/.config/
 
 Keybindings may be single characters (e.g. `a`, `B`) or [xkb key labels](https://github.com/xkbcommon/libxkbcommon/blob/master/include/xkbcommon/xkbcommon-keysyms.h) (without the `XKB_KEY_` prefix, e.g. `Return`, `Insert`). Ctrl and Alt modifiers are supported (like `Ctrl+Return` or `Ctrl+Alt+a`).
 
+When executed a command will normally end the `wlr_which_key` process. If you want certain commands to keep the UI open after they execute then
+configure those specific commands with (`keep_open: true`).
+
 Example config:
 
 ```yaml
@@ -56,7 +59,7 @@ menu:
     submenu:
       "d": { desc: Dark, cmd: dark-theme on }
       "l": { desc: Light, cmd: dark-theme off }
-      "t": { desc: Toggle, cmd: dark-theme toggle }
+      "t": { desc: Toggle, cmd: dark-theme toggle, keep_open: true }
   "l":
     desc: Laptop Screen
     submenu:

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,8 +51,16 @@ pub struct Config {
 #[derive(Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Entry {
-    Cmd { cmd: String, desc: String },
-    Recursive { submenu: Entries, desc: String },
+    Cmd {
+        cmd: String,
+        desc: String,
+        #[serde(default)]
+        keep_open: bool,
+    },
+    Recursive {
+        submenu: Entries,
+        desc: String,
+    },
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ impl KeyboardHandler for State {
                     self.exit = true;
                     conn.break_dispatch_loop();
                 }
-                menu::Action::Exec(cmd) => {
+                menu::Action::Exec { cmd, keep_open } => {
                     let mut proc = Command::new("sh");
                     proc.args(["-c", &cmd]);
                     proc.stdin(Stdio::null());
@@ -327,7 +327,9 @@ impl KeyboardHandler for State {
                         });
                     }
                     proc.spawn().unwrap().wait().unwrap();
-                    self.exit = true;
+                    if !keep_open {
+                        self.exit = true;
+                    }
                 }
                 menu::Action::Submenu(page) => {
                     self.menu.set_page(page);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -30,7 +30,7 @@ struct MenuItem {
 #[derive(Clone)]
 pub enum Action {
     Quit,
-    Exec(String),
+    Exec { cmd: String, keep_open: bool },
     Submenu(usize),
 }
 
@@ -74,8 +74,15 @@ impl Menu {
 
         for (key, entry) in &entries.0 {
             let item = match entry {
-                config::Entry::Cmd { cmd, desc } => MenuItem {
-                    action: Action::Exec(cmd.into()),
+                config::Entry::Cmd {
+                    cmd,
+                    desc,
+                    keep_open,
+                } => MenuItem {
+                    action: Action::Exec {
+                        cmd: cmd.into(),
+                        keep_open: *keep_open,
+                    },
                     key_comp: ComputedText::new(&key.repr, context, &config.font),
                     val_comp: ComputedText::new(desc, context, &config.font),
                     key: key.clone(),


### PR DESCRIPTION
This lets you execute one-shot commands repeatedly without the UI closing (giving you functionality similar to the hydra emacs package).

My initial use-case for this was for managing my notifications. I recently switched desktop-environment and my old environment had support for mode switching which allowed for this kind of thing out of the box. I just switched to `niri` and it doesn't seem to let you configure bindings like this. I use `mako` and I have one binding that clears all my notifications, and two others that let me restore or dismiss notifications one at a time.

I stumbled upon `wlr-which-key` and realized that if it supported this kind of use-case it would be a perfect fit. As an example, the kind of config I'm using now with my fork is as follows:

```yaml
menu: 
  "n": { desc: Dismiss all notifications, cmd: makoctl dismiss --all }
  "d": { desc: Dismiss latest notification, cmd: makoctl dismiss, keep_open: true }
  "r": { desc: Restore last notification, cmd: makoctl restore, keep_open: true }
```

This lets me `dismiss` and `restore` notifications with <kbd>d</kbd> and <kbd>r</kbd> without it closing the UI where I can then stop it with <kbd>Esc</kbd>. If I hit <kbd>n</kbd> it just clears all my notifications and then exits.