### PR TITLE
new config format, better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,35 +43,94 @@ margin_left: 0
 margin_top: 0
 
 menu: 
-  "w":
-    desc: WiFi
-    submenu:
-      "t": { desc: Toggle, cmd: wifi_toggle.sh }
-      "c": { desc: Connections, cmd: kitty --class nmtui-connect nmtui-connect }
-  "p":
+  - key: "p"
     desc: Power
     submenu:
-      "s": { desc: Sleep, cmd: systemctl suspend }
-      "r": { desc: Reboot, cmd: reboot }
-      "o": { desc: Off, cmd: poweroff }
-  "t":
-    desc: Theme
-    submenu:
-      "d": { desc: Dark, cmd: dark-theme on }
-      "l": { desc: Light, cmd: dark-theme off }
-      "t": { desc: Toggle, cmd: dark-theme toggle, keep_open: true }
-  "l":
+      - key: "s"
+        desc: Sleep
+        cmd: systemctl suspend
+      - key: "r"
+        desc: Reboot
+        cmd: reboot
+      - key: "o"
+        desc: Off
+        cmd: poweroff
+  - key: "l"
     desc: Laptop Screen
     submenu:
-      "t": { desc: Toggle On/Off, cmd: toggle-laptop-display.sh }
-      "s":
+      - key: "t"
+        desc: Toggle On/Off
+        cmd: toggle-laptop-display.sh
+      - key: "s"
         desc: Scale
         submenu:
-          "1": { desc: Set Scale to 1.0, cmd: wlr-randr --output eDP-1 --scale 1 }
-          "2": { desc: Set Scale to 1.1, cmd: wlr-randr --output eDP-1 --scale 1.1 }
-          "3": { desc: Set Scale to 1.2, cmd: wlr-randr --output eDP-1 --scale 1.2 }
-          "4": { desc: Set Scale to 1.3, cmd: wlr-randr --output eDP-1 --scale 1.3 }
+          - key: "1"
+            desc: Set Scale to 1.0
+            cmd: wlr-randr --output eDP-1 --scale 1
+          - key: "2"
+            desc: Set Scale to 1.1
+            cmd: wlr-randr --output eDP-1 --scale 1.1
+          - key: "3"
+            desc: Set Scale to 1.2
+            cmd: wlr-randr --output eDP-1 --scale 1.2
+          - key: "4"
+            desc: Set Scale to 1.3
+            cmd: wlr-randr --output eDP-1 --scale 1.3
 ```
+
+<details>
+  <summary> Old config format (v1.1.0 and earlier) </summary>
+
+  ```yaml
+  # Theming
+  font: JetBrainsMono Nerd Font 12
+  background: "#282828d0"
+  color: "#fbf1c7"
+  border: "#8ec07c"
+  separator: " ➜ "
+  border_width: 2
+  corner_r: 10
+  padding: 15 # Defaults to corner_r
+
+  # Anchor and margin
+  anchor: center # One of center, left, right, top, bottom, bottom-left, top-left, etc.
+  # Only relevant when anchor is not center
+  margin_right: 0
+  margin_bottom: 0
+  margin_left: 0
+  margin_top: 0
+
+  menu: 
+    "w":
+      desc: WiFi
+      submenu:
+        "t": { desc: Toggle, cmd: wifi_toggle.sh }
+        "c": { desc: Connections, cmd: kitty --class nmtui-connect nmtui-connect }
+    "p":
+      desc: Power
+      submenu:
+        "s": { desc: Sleep, cmd: systemctl suspend }
+        "r": { desc: Reboot, cmd: reboot }
+        "o": { desc: Off, cmd: poweroff }
+    "t":
+      desc: Theme
+      submenu:
+        "d": { desc: Dark, cmd: dark-theme on }
+        "l": { desc: Light, cmd: dark-theme off }
+        "t": { desc: Toggle, cmd: dark-theme toggle, keep_open: true }
+    "l":
+      desc: Laptop Screen
+      submenu:
+        "t": { desc: Toggle On/Off, cmd: toggle-laptop-display.sh }
+        "s":
+          desc: Scale
+          submenu:
+            "1": { desc: Set Scale to 1.0, cmd: wlr-randr --output eDP-1 --scale 1 }
+            "2": { desc: Set Scale to 1.1, cmd: wlr-randr --output eDP-1 --scale 1.1 }
+            "3": { desc: Set Scale to 1.2, cmd: wlr-randr --output eDP-1 --scale 1.2 }
+            "4": { desc: Set Scale to 1.3, cmd: wlr-randr --output eDP-1 --scale 1.3 }
+  ```
+</details>
 
 ![image](https://user-images.githubusercontent.com/34583604/233025292-af0d5798-1854-4809-b08f-2e8f1a65b3ce.png)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,22 +1,20 @@
+mod anchor;
+mod compat;
+mod entry;
+mod font;
+
 use std::env;
-use std::fmt;
 use std::fs::read_to_string;
-use std::ops::Deref;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
-use indexmap::IndexMap;
-use pangocairo::pango::FontDescription;
-use serde::{de, Deserialize};
+use serde::Deserialize;
 use smart_default::SmartDefault;
-use wayrs_protocols::wlr_layer_shell_unstable_v1::zwlr_layer_surface_v1::Anchor;
 
+pub use self::anchor::ConfigAnchor;
+pub use self::entry::Entry;
+pub use self::font::Font;
 use crate::color::Color;
-use crate::key::Key;
-
-#[derive(Deserialize, Default)]
-#[serde(transparent)]
-pub struct Entries(pub IndexMap<Key, Entry>);
 
 #[derive(Deserialize, SmartDefault)]
 #[serde(deny_unknown_fields, default)]
@@ -45,22 +43,7 @@ pub struct Config {
     // defaults to `corner_r`
     pub padding: Option<f64>,
 
-    pub menu: Entries,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum Entry {
-    Cmd {
-        cmd: String,
-        desc: String,
-        #[serde(default)]
-        keep_open: bool,
-    },
-    Recursive {
-        submenu: Entries,
-        desc: String,
-    },
+    pub menu: Vec<Entry>,
 }
 
 impl Config {
@@ -74,8 +57,20 @@ impl Config {
             bail!("config file not found: {}", config_path.display());
         }
 
-        let config = read_to_string(config_path).context("Failed to read configuration")?;
-        serde_yaml::from_str(&config).context("Failed to deserialize configuration")
+        let config_str = read_to_string(config_path).context("Failed to read configuration")?;
+
+        match serde_yaml::from_str::<Self>(&config_str)
+            .context("Failed to deserialize configuration")
+        {
+            Ok(config) => Ok(config),
+            Err(err) => match serde_yaml::from_str::<compat::Config>(&config_str) {
+                Ok(compat) => {
+                    eprintln!("Warning: using the old config format, which will be removed in a future version.");
+                    Ok(compat.into())
+                }
+                Err(_compat_err) => Err(err),
+            },
+        }
     }
 
     pub fn padding(&self) -> f64 {
@@ -87,81 +82,4 @@ fn config_dir() -> Option<PathBuf> {
     env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .or_else(|| Some(PathBuf::from(env::var_os("HOME")?).join(".config")))
-}
-
-pub struct Font(pub FontDescription);
-
-impl Font {
-    pub fn new(desc: &str) -> Self {
-        Self(FontDescription::from_string(desc))
-    }
-}
-
-impl Deref for Font {
-    type Target = FontDescription;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<'de> de::Deserialize<'de> for Font {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        struct FontVisitor;
-
-        impl de::Visitor<'_> for FontVisitor {
-            type Value = Font;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("font description")
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(Font::new(s))
-            }
-        }
-
-        deserializer.deserialize_str(FontVisitor)
-    }
-}
-
-/// Light wrapper around `Anchor` which also supports the "no anchor" value.
-///
-/// This type is also requires to derive `Deserialize` for the foreign type.
-#[derive(Deserialize, Default, Clone, Copy)]
-#[serde(rename_all(deserialize = "kebab-case"))]
-pub enum ConfigAnchor {
-    #[default]
-    Center,
-    Top,
-    Bottom,
-    Left,
-    Right,
-    TopLeft,
-    TopRight,
-    BottomLeft,
-    BottomRight,
-}
-
-/// Convert this anchor into the type expected by `wayrs`.
-impl From<ConfigAnchor> for Anchor {
-    fn from(value: ConfigAnchor) -> Self {
-        match value {
-            ConfigAnchor::Center => Anchor::empty(),
-            ConfigAnchor::Top => Anchor::Top,
-            ConfigAnchor::Bottom => Anchor::Bottom,
-            ConfigAnchor::Left => Anchor::Left,
-            ConfigAnchor::Right => Anchor::Right,
-            ConfigAnchor::TopLeft => Anchor::Top | Anchor::Left,
-            ConfigAnchor::TopRight => Anchor::Top | Anchor::Right,
-            ConfigAnchor::BottomLeft => Anchor::Bottom | Anchor::Left,
-            ConfigAnchor::BottomRight => Anchor::Bottom | Anchor::Right,
-        }
-    }
 }

--- a/src/config/anchor.rs
+++ b/src/config/anchor.rs
@@ -1,0 +1,37 @@
+use serde::Deserialize;
+use wayrs_protocols::wlr_layer_shell_unstable_v1::zwlr_layer_surface_v1::Anchor;
+
+/// Light wrapper around `Anchor` which also supports the "no anchor" value.
+///
+/// This type is also requires to derive `Deserialize` for the foreign type.
+#[derive(Deserialize, Default, Clone, Copy)]
+#[serde(rename_all(deserialize = "kebab-case"))]
+pub enum ConfigAnchor {
+    #[default]
+    Center,
+    Top,
+    Bottom,
+    Left,
+    Right,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+/// Convert this anchor into the type expected by `wayrs`.
+impl From<ConfigAnchor> for Anchor {
+    fn from(value: ConfigAnchor) -> Self {
+        match value {
+            ConfigAnchor::Center => Anchor::empty(),
+            ConfigAnchor::Top => Anchor::Top,
+            ConfigAnchor::Bottom => Anchor::Bottom,
+            ConfigAnchor::Left => Anchor::Left,
+            ConfigAnchor::Right => Anchor::Right,
+            ConfigAnchor::TopLeft => Anchor::Top | Anchor::Left,
+            ConfigAnchor::TopRight => Anchor::Top | Anchor::Right,
+            ConfigAnchor::BottomLeft => Anchor::Bottom | Anchor::Left,
+            ConfigAnchor::BottomRight => Anchor::Bottom | Anchor::Right,
+        }
+    }
+}

--- a/src/config/compat.rs
+++ b/src/config/compat.rs
@@ -1,0 +1,102 @@
+use indexmap::IndexMap;
+use serde::Deserialize;
+use smart_default::SmartDefault;
+
+use crate::color::Color;
+use crate::key::Key;
+
+use super::{ConfigAnchor, Font};
+
+#[derive(Deserialize, Default)]
+#[serde(transparent)]
+pub struct Entries(pub IndexMap<Key, Entry>);
+
+#[derive(Deserialize, SmartDefault)]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    #[default(Color::from_rgba_hex(0x282828ff))]
+    pub background: Color,
+    #[default(Color::from_rgba_hex(0xfbf1c7ff))]
+    pub color: Color,
+    #[default(Color::from_rgba_hex(0x8ec07cff))]
+    pub border: Color,
+
+    pub anchor: ConfigAnchor,
+    pub margin_top: i32,
+    pub margin_right: i32,
+    pub margin_bottom: i32,
+    pub margin_left: i32,
+
+    #[default(Font::new("monospace 10"))]
+    pub font: Font,
+    #[default(" ➜ ".into())]
+    pub separator: String,
+    #[default(4.0)]
+    pub border_width: f64,
+    #[default(20.0)]
+    pub corner_r: f64,
+    // defaults to `corner_r`
+    pub padding: Option<f64>,
+
+    pub menu: Entries,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum Entry {
+    Cmd {
+        cmd: String,
+        desc: String,
+        #[serde(default)]
+        keep_open: bool,
+    },
+    Recursive {
+        submenu: Entries,
+        desc: String,
+    },
+}
+
+impl From<Config> for super::Config {
+    fn from(value: Config) -> Self {
+        fn map_entries(value: Entries) -> Vec<super::Entry> {
+            value
+                .0
+                .into_iter()
+                .map(|(key, entry)| match entry {
+                    Entry::Cmd {
+                        cmd,
+                        desc,
+                        keep_open,
+                    } => super::Entry::Cmd {
+                        key,
+                        cmd,
+                        desc,
+                        keep_open,
+                    },
+                    Entry::Recursive { submenu, desc } => super::Entry::Recursive {
+                        key,
+                        submenu: map_entries(submenu),
+                        desc,
+                    },
+                })
+                .collect()
+        }
+
+        Self {
+            background: value.background,
+            color: value.color,
+            border: value.border,
+            anchor: value.anchor,
+            margin_top: value.margin_top,
+            margin_right: value.margin_right,
+            margin_bottom: value.margin_bottom,
+            margin_left: value.margin_left,
+            font: value.font,
+            separator: value.separator,
+            border_width: value.border_width,
+            corner_r: value.corner_r,
+            padding: value.padding,
+            menu: map_entries(value.menu),
+        }
+    }
+}

--- a/src/config/entry.rs
+++ b/src/config/entry.rs
@@ -1,0 +1,59 @@
+use anyhow::{bail, Context};
+use serde::Deserialize;
+
+use crate::key::Key;
+
+#[derive(Deserialize)]
+#[serde(try_from = "RawEntry")]
+pub enum Entry {
+    Cmd {
+        key: Key,
+        cmd: String,
+        desc: String,
+        keep_open: bool,
+    },
+    Recursive {
+        key: Key,
+        submenu: Vec<Self>,
+        desc: String,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawEntry {
+    key: Key,
+    desc: String,
+    cmd: Option<String>,
+    keep_open: Option<bool>,
+    submenu: Option<Vec<Entry>>,
+}
+
+impl TryFrom<RawEntry> for Entry {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawEntry) -> Result<Self, Self::Error> {
+        if let Some(submenu) = value.submenu {
+            if value.cmd.is_some() {
+                bail!("cannot have both 'submenu' and 'cmd'");
+            }
+            if value.keep_open.is_some() {
+                bail!("cannot have both 'submenu' and 'keep_open'");
+            }
+            Ok(Self::Recursive {
+                key: value.key,
+                submenu,
+                desc: value.desc,
+            })
+        } else {
+            Ok(Self::Cmd {
+                key: value.key,
+                cmd: value
+                    .cmd
+                    .context("either or 'submenu' or 'cmd' is required")?,
+                desc: value.desc,
+                keep_open: value.keep_open.unwrap_or(false),
+            })
+        }
+    }
+}

--- a/src/config/font.rs
+++ b/src/config/font.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+
+use pangocairo::pango::FontDescription;
+use serde::de;
+
+pub struct Font(pub FontDescription);
+
+impl Font {
+    pub fn new(desc: &str) -> Self {
+        Self(FontDescription::from_string(desc))
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Font {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct FontVisitor;
+
+        impl de::Visitor<'_> for FontVisitor {
+            type Value = Font;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("font description")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Font::new(s))
+            }
+        }
+
+        deserializer.deserialize_str(FontVisitor)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,10 +315,7 @@ impl KeyboardHandler for State {
                     // Safety: libc::daemon() is async-signal-safe
                     unsafe {
                         proc.pre_exec(|| match libc::daemon(1, 0) {
-                            -1 => Err(io::Error::new(
-                                io::ErrorKind::Other,
-                                "Failed to detach new process",
-                            )),
+                            -1 => Err(io::Error::other("Failed to detach new process")),
                             _ => Ok(()),
                         });
                     }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -43,7 +43,7 @@ impl Menu {
         let mut this = Self {
             pages: Vec::new(),
             cur_page: 0,
-            separator: ComputedText::new(&config.separator, &context, &config.font),
+            separator: ComputedText::new(&config.separator, &context, &config.font.0),
         };
 
         this.push_page(&context, &config.menu, config, None)?;
@@ -54,11 +54,11 @@ impl Menu {
     fn push_page(
         &mut self,
         context: &pango::Context,
-        entries: &config::Entries,
+        entries: &[config::Entry],
         config: &Config,
         parent: Option<usize>,
     ) -> Result<usize> {
-        if entries.0.is_empty() {
+        if entries.is_empty() {
             bail!("Empty menu pages are not allowed");
         }
 
@@ -72,9 +72,10 @@ impl Menu {
             parent,
         });
 
-        for (key, entry) in &entries.0 {
+        for entry in entries {
             let item = match entry {
                 config::Entry::Cmd {
+                    key,
                     cmd,
                     desc,
                     keep_open,
@@ -83,19 +84,20 @@ impl Menu {
                         cmd: cmd.into(),
                         keep_open: *keep_open,
                     },
-                    key_comp: ComputedText::new(&key.repr, context, &config.font),
-                    val_comp: ComputedText::new(desc, context, &config.font),
+                    key_comp: ComputedText::new(&key.repr, context, &config.font.0),
+                    val_comp: ComputedText::new(desc, context, &config.font.0),
                     key: key.clone(),
                 },
                 config::Entry::Recursive {
+                    key,
                     submenu: entries,
                     desc,
                 } => {
                     let new_page = self.push_page(context, entries, config, Some(cur_page))?;
                     MenuItem {
                         action: Action::Submenu(new_page),
-                        key_comp: ComputedText::new(&key.repr, context, &config.font),
-                        val_comp: ComputedText::new(&format!("+{desc}"), context, &config.font),
+                        key_comp: ComputedText::new(&key.repr, context, &config.font.0),
+                        val_comp: ComputedText::new(&format!("+{desc}"), context, &config.font.0),
                         key: key.clone(),
                     }
                 }


### PR DESCRIPTION
Closes #12
Is needed for #10

Old config format still works with a warning.

Config before:

```yaml
menu: 
  "p":
    desc: Power
    submenu:
      "s": { desc: Sleep, cmd: systemctl suspend }
      "r": { desc: Reboot, cmd: reboot }
      "o": { desc: Off, cmd: poweroff }
```

Config after:

```yaml
menu: 
  - key: "p"
    desc: Power
    submenu:
      - key: "s"
        desc: Sleep
        cmd: systemctl suspend
      - key: "r"
        desc: Reboot
        cmd: reboot
      - key: "o"
        desc: Off
        cmd: poweroff
```

Errors before:

```text
Error: Failed to deserialize configuration

Caused by:
    menu: data did not match any variant of untagged enum Entry at line 15 column 3
```

Errors after:

```text
Error: Failed to deserialize configuration

Caused by:
    menu[1].submenu[0]: missing field `desc` at line 27 column 9
```