### PR TITLE
Add flake.nix with package and home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,148 @@ Keymap manager for wlroots-based compositors. Inspired by [which-key.nvim](https
 cargo install wlr-which-key --locked
 ```
 
+### Nix
+
+This repository provides the flake outputs:
+```nix
+packages.${system}.wlr-which-key
+homeManagerModules.wlr-which-key
+```
+
+#### Nix profile
+
+```sh
+nix profile install github:MaxVerevkin/wlr-which-key
+```
+
+#### Flakes
+
+<details>
+  <summary>Example flake</summary>
+
+  ```nix
+    {
+      inputs = {
+        # other inputs...      
+        wlr-which-key = {
+          url = "github:MaxVerevkin/wlr-which-key";
+          # Optionally, pin the nixpkgs version to the one in your flake:
+          inputs.nixpkgs.follows = "nixpkgs"; # Replace "nixpkgs" with the name of your nixpkgs flake input
+        };
+      };
+      
+      # the rest of your flake, outputs, etc ...
+    }
+  ```
+</details>
+
+You can then use the package in your flake by referencing `inputs.wlr-which-key.packages.${pkgs.system}.wlr-which-key`.
+
+#### Home Manager (with flakes)
+
+<details>
+  <summary>Example module</summary>
+
+  ```nix
+  {
+    pkgs,
+    inputs,
+    ...
+  }:
+  {
+    imports = [
+      inputs.wlr-which-key.homeManagerModules.wlr-which-key
+    ];
+    programs.wlr-which-key = {
+      enable = true;
+      package = inputs.wlr-which-key.${pkgs.system}.wlr-which-key; # Optional, the default is the package the flake provides
+      # The following is equivelent to the example config, but in nix
+      settings = {
+        font = "JetBrainsMono Nerd Font 12";
+        background = "#282828d0";
+        color = "#fbf1c7";
+        border = "#8ec07c";
+        separator = " ➜ ";
+        border_width = 2;
+        corner_r = 10;
+        padding = 15; 
+        rows_per_column = 5;
+        column_padding = 25;
+
+        anchor = "center";
+        margin_right = 0;
+        margin_bottom = 0;
+        margin_left = 0;
+        margin_top = 0;
+
+        inhibit_compositor_keyboard_shortcuts = true;
+
+        menu = [
+          {
+            key = "p";
+            desc = "Power";
+            submenu = [
+              {
+                key = "s";
+                desc = "Sleep";
+                cmd = "systemctl suspend";
+              }
+              {
+                key = "r";
+                desc = "Reboot";
+                cmd = "reboot";
+              }
+              {
+                key = "o";
+                desc = "Off";
+                cmd = "poweroff";
+              }
+            ];
+          }
+          {
+            key = "l";
+            desc = "Laptop Screen";
+            submenu = [
+              {
+                key = "t";
+                desc = "Toggle On/Off";
+                cmd = "toggle-laptop-display.sh";
+              }
+              {
+                key = "s";
+                desc = "Scale";
+                submenu = [
+                  {
+                    key = "1";
+                    desc = "Set Scale to 1.0";
+                    cmd = "wlr-randr --output eDP-1 --scale 1";
+                  }
+                  {
+                    key = "2";
+                    desc = "Set Scale to 1.1";
+                    cmd = "wlr-randr --output eDP-1 --scale 1.1";
+                  }
+                  {
+                    key = "3";
+                    desc = "Set Scale to 1.2";
+                    cmd = "wlr-randr --output eDP-1 --scale 1.2";
+                  }
+                  {
+                    key = "4";
+                    desc = "Set Scale to 1.3";
+                    cmd = "wlr-randr --output eDP-1 --scale 1.3";
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
+    };
+  }
+  ```
+</details>
+
 ## Configuration
 
 Default config file: `$XDG_CONFIG_HOME/wlr-which-key/config.yaml` or `~/.config/wlr-which-key/config.yaml`. Run `wlr-which-key --help` for more info.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This repository provides the flake outputs:
 packages.${system}.wlr-which-key
 homeManagerModules.wlr-which-key
 ```
+Or you can use the version from nixpkgs (`pkgs.wlr-which-key`)
+
+If you use the package in this flake, you will have to build it locally.
 
 #### Nix profile
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742800061,
+        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+{
+  description = "Keymap manager for wlroots-based compositors";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      systems,
+      ...
+    }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (system: rec {
+        default = wlr-which-key;
+        wlr-which-key =
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            craneLib = crane.mkLib pkgs;
+            inherit (pkgs) lib;
+          in
+          craneLib.buildPackage {
+            src = craneLib.cleanCargoSource ./.;
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              glib
+              pango
+              libxkbcommon
+            ];
+            meta = {
+              description = "Keymap manager for wlroots-based compositors";
+              mainProgram = "wlr-which-key";
+              homepage = "https://github.com/MaxVerevkin/wlr-which-key";
+              license = lib.licenses.gpl3Only;
+              platforms = lib.platforms.linux;
+            };
+          };
+      });
+
+      homeManagerModules = rec {
+        default = wlr-which-key;
+        wlr-which-key =
+          {
+            config,
+            pkgs,
+            lib,
+            options,
+            ...
+          }:
+          let
+            cfg = config.programs.wlr-which-key;
+            opt = options.programs.wlr-which-key;
+            inherit (lib)
+              types
+              mkOption
+              mkEnableOption
+              literalExample
+              ;
+          in
+          {
+            options.programs.wlr-which-key = {
+              enable = mkEnableOption "Enable wlr-which-key";
+              package = mkOption {
+                description = "The wlr-which-key package to use";
+                type = types.package;
+                default = self.packages.${pkgs.system}.wlr-which-key;
+                example = literalExample "pkgs.wlr-which-key";
+              };
+              settings = mkOption {
+                description = ''
+                  The configuration for wlr-which-key, to be placed at $XDG_CONFIG_HOME/wlr-which-key/config.yaml
+                  If it is a set, config.yaml is generated with pkgs.formats.yaml.
+                  If it is a string, config.yaml is the string verbatim.
+                '';
+                default = { };
+                type = types.either (types.attrsOf types.anything) types.str;
+              };
+            };
+            config = lib.mkIf cfg.enable {
+              home.packages = [ cfg.package ];
+
+              xdg.configFile."wlr-which-key/config.yaml" =
+                let
+                  types = opt.settings.type.nestedTypes;
+                  inherit (cfg) settings;
+                in
+                {
+                  source = lib.mkIf (types.left.check settings) (
+                    (pkgs.formats.yaml { }).generate "wlr-which-key-config.yaml" settings
+                  );
+                  text = lib.mkIf (types.right.check settings) settings;
+                };
+            };
+          };
+      };
+
+      devShells = eachSystem (system: rec {
+        default = wlr-which-key;
+        wlr-which-key =
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            craneLib = crane.mkLib pkgs;
+          in
+          craneLib.devShell {
+            inherit (self.packages.wlr-which-key) nativeBuildInputs;
+          };
+      });
+    };
+}


### PR DESCRIPTION
Adds a nix flake with:
- package
- homeManagerModule
- devShell

(All tested)

This allows nix(os) +/ home-manager users to easily use and configure this program, i.e:
```nix
{
  programs.wlr-which-key = {
    enable = true;
    settings = {
      font = "JetBrainsMono Nerd Font 12";
      # .. etc
    };
}
```

Things that i should probably add (if you want) before you merge this:
- ~~A section in the readme about installing/configuring with nix (nix profile + home-manager) with an example config~~ - Done

p.s: Very nice project :) (previously was trying to acheive something similar by doing some horribly hacky stuff with bemenu...)