### PR TITLE
Don't allow markup in key or desc config

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -22,7 +22,7 @@ impl ComputedText {
     pub fn new(text: impl AsRef<str>, context: &pango::Context, font: &FontDescription) -> Self {
         let layout = pango::Layout::new(context);
         layout.set_font_description(Some(font));
-        layout.set_markup(text.as_ref());
+        layout.set_text(text.as_ref());
 
         let (width, height) = layout.pixel_size();
 


### PR DESCRIPTION
Before the key and desc values where added with pango's set_markup function. This fails when the key is "<" as pango expects this to be the start of a markup tag.

By using set_text instead this problem is solved with the drawback of not allowing markup in the description of a key. However the documentation does not advertise that the description could contain markup nor does it seem to be a sensible feature.

Fixes: https://github.com/MaxVerevkin/wlr-which-key/issues/26