### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -529,7 +529,7 @@ fn exec(cmd: &str) {
     // Safety: libc::daemon() is async-signal-safe
     unsafe {
         proc.pre_exec(|| match libc::daemon(1, 0) {
-            -1 => Err(io::Error::other("Failed to detach new process")),
+            -1 => Err(io::Error::last_os_error()),
             _ => Ok(()),
         });
     }


### PR DESCRIPTION
`Error::other` allocates memory (see https://github.com/rust-lang/rust/pull/148971) and thus isn't async-signal-safe. `last_os_error` is. It isn't possible to transmit the error message across `pre_exec`, unless you're willing to write to `stderr`, but the old method swallowed the text too, so hopefully that isn't a problem.